### PR TITLE
纠正用channel实现控制并发数的问题

### DIFF
--- a/golang/go-Interview/GOALNG_INTERVIEW_COLLECTION.md
+++ b/golang/go-Interview/GOALNG_INTERVIEW_COLLECTION.md
@@ -1594,21 +1594,19 @@ mutex 会让当前的 goroutine 去空转 CPU，在空转完后再次调用 CAS 
 
 ```go
 func main() {
-    count := 10                     // 最大支持并发
-    sum := 100                      // 任务总数
-    wg := sync.WaitGroup{}          //控制主协程等待所有子协程执行完之后再退出。
+    count := 10 // 最大支持并发
+    sum := 100 // 任务总数
+ 
     c := make(chan struct{}, count) // 控制任务并发的chan
     defer close(c)
-    for i := 0; i < sum; i++ {
-        wg.Add(1)
+ 
+    for i:=0; i<sum;i++{
         c <- struct{}{} // 作用类似于waitgroup.Add(1)
         go func(j int) {
-            defer wg.Done()
             fmt.Println(j)
-            <-c // 执行完毕，释放资源
+            <- c // 执行完毕，释放资源
         }(i)
     }
-    wg.Wait()
 }
 ```
 


### PR DESCRIPTION
使用channel控制并发数，问什么还要同时使用waitgroup？仅使用channel就可以实现，或不适用channel直接用waitgroup实现等待